### PR TITLE
Fix specnum dispatch, SSA normalisation, and cutoff smoothing exponent

### DIFF
--- a/gsspectshapes.py
+++ b/gsspectshapes.py
@@ -35,51 +35,59 @@ class Spectrum:
     
     def spectrum(self): # FIXME something bad will probably happen if any of the frequencies are equal
         """"""
-        if (self._nuac <= self._nusa <= self._num <= self._nuc) or self._specnum == 1: # spectrum 1
+        # When `specnum` is explicitly given (e.g. by RSjetStruct._spectrumweighted
+        # forcing each component of a weighted-average sum), honour it
+        # unconditionally. Otherwise fall back to dispatching by the natural
+        # break-frequency ordering. The previous form `(ordering) or specnum==N`
+        # let the natural ordering short-circuit the explicit specnum, which
+        # silently collapsed `y22` to `y12` whenever the actual breaks were in
+        # spec-1 ordering, making the weighted sum a no-op.
+        sn = self._specnum
+        if sn == 1 or (sn is None and self._nuac <= self._nusa <= self._num <= self._nuc): # spectrum 1
             if self._Fnu1 is None:
                 # Fnu1 = self._Fnumax/self._spectrum1(self._num, 1); # TODO
                 Fnu1 = self._Fnumax * (self._nusa/self._num)**self._getSlope(2)[0]
             else:
                 Fnu1 = self._Fnu1
-            
+
             spec = self._spectrum1(self._nu, Fnu1)
-            
-        elif (self._nuac <= self._num <= self._nusa <= self._nuc) or self._specnum == 2: # spectrum 2
+
+        elif sn == 2 or (sn is None and self._nuac <= self._num <= self._nusa <= self._nuc): # spectrum 2
             if self._Fnu4 is None:
                 #Fnu4 = self._Fnumax/self._spectrum2(self._nusa, 1)
                 Fnu4 = self._Fnumax * (self._num/self._nusa)**self._getSlope(5)[0]
             else:
                 Fnu4 = self._Fnu4
-            
+
             spec = self._spectrum2(self._nu, Fnu4)
-            
-        elif (self._nuac <= self._nusa and self._num <= self._nusa and self._nuc <= self._nusa) or self._specnum == 3: # spectrum 3
+
+        elif sn == 3 or (sn is None and self._nuac <= self._nusa and self._num <= self._nusa and self._nuc <= self._nusa): # spectrum 3
             if self._Fnu4 is None:
                 #Fnu4 = self._Fnumax/self._spectrum3(self._nusa, 1)
                 Fnu4 = self._Fnumax * (self._num/self._nusa)**self._getSlope(5)[0]
             else:
                 Fnu4  = self._Fnu4
-            
+
             spec = self._spectrum3(self._nu, Fnu4)
-            
-        elif (self._nuac <= self._nusa and self._nuc <= self._nusa and self._nusa <= self._num) or self._specnum == 4: # spectrum 4
+
+        elif sn == 4 or (sn is None and self._nuac <= self._nusa and self._nuc <= self._nusa and self._nusa <= self._num): # spectrum 4
             if self._Fnu7 is None:
                 #Fnu7 = self._Fnumax/self._spectrum4(self._nusa, 1)
                 Fnu7 = self._Fnumax * (self._nuac/self._nusa)**self._getSlope(8)[0]
             else:
                 Fnu7 = self._Fnu7
-            
+
             spec = self._spectrum4(self._nu, Fnu7)
-            
-        elif (self._nuac <= self._nusa <= self._nuc <= self._num) or self._specnum == 5: # spectrum 5
+
+        elif sn == 5 or (sn is None and self._nuac <= self._nusa <= self._nuc <= self._num): # spectrum 5
             if self._Fnu7 is None:
                 #Fnu7 = self._Fnumax/self._spectrum5(self._nuc, 1)
                 Fnu7 = self._Fnumax * (self._nusa/self._nuc)**self._getSlope(11)[0] * (self._nuac/self._nusa)**self._getSlope(10)[0]
             else:
                 Fnu7 = self._Fnu7
-            
+
             spec = self._spectrum5(self._nu, Fnu7)
-        
+
         else:
             raise Exception("nuac must be smaller than nusa")
         
@@ -111,16 +119,16 @@ class Spectrum:
         
         s = self._getSlope(12)[2]
         
-        return (tildeFnu3**(-s) + tildeFnu3atnu3**(-s) * np.exp(-s) * (np.exp(s * (nu/self._nub(3)))))**(-s)
-    
+        return (tildeFnu3**(-s) + tildeFnu3atnu3**(-s) * np.exp(-s) * (np.exp(s * (nu/self._nub(3)))))**(-1/s)
+
     def _FnuCUT3(self, nu, Fnu4):
         """Cutoff for spectra 3"""
         precut = Spectrum._Fnu4(nu, self._nub(4), Fnu4, *self._getSlope(4)) * Spectrum._tildeFnub(nu, self._nub(6), *self._getSlope(6))
         precutatnu3or11 = Spectrum._Fnu4(self._nuc, self._nub(4), Fnu4, *self._getSlope(4)) * Spectrum._tildeFnub(nu, self._nub(6), *self._getSlope(6))
-        
+
         s = self._getSlope(13)[2]
-        
-        return (precut**(-s) + precutatnu3or11**(-s) * np.exp(-s) * (np.exp(s * (nu/self._nuc))))**(-s)
+
+        return (precut**(-s) + precutatnu3or11**(-s) * np.exp(-s) * (np.exp(s * (nu/self._nuc))))**(-1/s)
     
     def _FnuCUT4(self, nu, Fnu7):
         """Cutoff for spectra 4"""
@@ -133,7 +141,7 @@ class Spectrum:
             
         s = self._getSlope(14)[2]           
             
-        return (precut**(-s) + precutatnu11**(-s) * np.exp(-s) * (np.exp(s * (nu/self._nub(11)))))**(-s)
+        return (precut**(-s) + precutatnu11**(-s) * np.exp(-s) * (np.exp(s * (nu/self._nub(11)))))**(-1/s)
     
     def _tildeFnuCUT5(self, nu):
         """Cutoff for spectra 5"""
@@ -142,7 +150,7 @@ class Spectrum:
             
         s = self._getSlope(15)[2]
             
-        return (tildeFnu11**(-s) + tildeFnu11atnu11**(-s) * np.exp(-s) * (np.exp(s * (nu/self._nub(11)))))**(-s)
+        return (tildeFnu11**(-s) + tildeFnu11atnu11**(-s) * np.exp(-s) * (np.exp(s * (nu/self._nub(11)))))**(-1/s)
     
     def _spectrum1(self, nu, Fnu1):
         """GS02 (5).

--- a/rsjetstruct.py
+++ b/rsjetstruct.py
@@ -28,6 +28,33 @@ def obsFluxMax(Fnumax_nossa, nuac, nusa, num, nuc, p):
         warnings.warn("No cases satisfied in obsFluxMax, flux returned is zero! Check input parameters.", RuntimeWarning)
     return F1 + F2 + F3 + F4 + F5
 
+
+def obsFluxMaxBySpecnum(Fnumax_nossa, nuac, nusa, num, nuc, p, specnum):
+    """obsFluxMax restricted to a given specnum, regardless of the actual
+    break-frequency ordering. Mirrors the case formulae of obsFluxMax but
+    selects by `specnum` directly. Used by RSjetStruct._spectrum when a
+    spectrum index is explicitly forced (the weighted-average path) so
+    that the SSA normalisation matches rs.py.calc_spect's per-specnum
+    formulae rather than the spec-1 normalisation that obsFluxMax would
+    silently fall through to when the actual ordering does not match the
+    forced specnum."""
+    if specnum == 1:
+        return Fnumax_nossa
+    elif specnum == 2:
+        return Fnumax_nossa * (nusa/num)**(-(p - 1)/2)
+    elif specnum == 3:
+        if num <= nuc:
+            return Fnumax_nossa * (nuc/num)**(-(p - 1)/2) * (nusa/nuc)**(-p/2)
+        else:
+            return Fnumax_nossa * (num/nuc)**(-1/2) * (nusa/num)**(-p/2)
+    elif specnum == 4:
+        return Fnumax_nossa * (nusa/nuc)**(-1/2)
+    elif specnum == 5:
+        return Fnumax_nossa
+    else:
+        raise ValueError("unsupported specnum=" + str(specnum))
+
+
     # if nuac <= nusa <= num <= nuc: # spectrum 1
     #     return Fnumax_nossa
     # elif nuac <= num <= nusa <= nuc: # spectrum 2
@@ -327,7 +354,7 @@ class RSjetStruct:
                 y22 = RSjetStruct._spectrum(self._tobs, self._nu, self._tcross, self._Fnumaxrs, self._numrs, self._nucutrs, self._nuars, self._p, self._k, specnum = 2, decelerated = True) # calc_spect(2, fsparams, f, nua, num, nuc, fnumax, decelerated=True)
                 y32 = RSjetStruct._spectrum(self._tobs, self._nu, self._tcross, self._Fnumaxrs, self._numrs, self._nucutrs, self._nuars, self._p, self._k, specnum = 3, decelerated = True)
                 
-                if tx3 is np.nan or tx2 >= largeTime: # if no second crossing then always in spectrum 1 post deceleration
+                if tx3 is np.nan or tx3 >= largeTime: # if no second crossing then always in spectrum 1 post deceleration
                     spect = (w31*y31 + w21*y21 + w11*y11)/(w31+w21+w11)*(self._tobs < self._tcross) + y12*(self._tobs >= self._tcross)
                 elif tx4 is np.nan or tx4 >= largeTime:    
                     spect = (w31*y31 + w21*y21 + w11*y11)/(w31+w21+w11)*(self._tobs < self._tcross) + (w12a*y12 + w22a*y22)/(w12a+w22a)*(self._tobs >= self._tcross)            
@@ -368,20 +395,28 @@ class RSjetStruct:
                 
             if (self._numrs_tcross < self._nucutrs_tcross < self._nuars_tcross): # TODO
                 # No crossings pre deceleration
+                # tx4 is the first chronological post-decel crossing (nua = nucut),
+                # tx3 is the second (nua = num). Ordering at tcross is num < nucut < nua,
+                # and nua descends through nucut first then num.
                 if self._kGamma <= 1:
                     tx3 = self._tnuarseqnumrsPostCrossWindCaseIc # (self._numrs_tcross/self._nuars_tcross)**(1/(laD2-lm2))*tdec
                     tx4 = self._tnuarseqnucutrsPostCrossWindCaseIc # (nuc3/nua3)**(1/(laE2-lc2))*tx3
                 else:
                     tx3 = self._tnuarseqnumrsPostCrossWindCaseIIc
                     tx4 = self._tnuarseqnucutrsPostCrossWindCaseIIc # (nuc3/nua3)**(1/(laE2-lc2))*tx3
-               
+
+                w32a = 1/(1 + (self._tobs/tx4)**pl)
+                w22a = 1/(1 + (self._tobs/tx4)**(-pl))
+                w22b = 1/(1 + (self._tobs/tx3)**pl)
+                w12b = 1/(1 + (self._tobs/tx3)**(-pl))
+
                 y31 = RSjetStruct._spectrum(self._tobs, self._nu, self._tcross, self._Fnumaxrs, self._numrs, self._nucutrs, self._nuars, self._p, self._k, specnum = 3, decelerated = False) # calc_spect(3, fsparams, f, nua, num, nuc, fnumax, decelerated=False)
                 y32 = RSjetStruct._spectrum(self._tobs, self._nu, self._tcross, self._Fnumaxrs, self._numrs, self._nucutrs, self._nuars, self._p, self._k, specnum = 3, decelerated = True) # calc_spect(3, fsparams, f, nua, num, nuc, fnumax, decelerated=True)
-                y22 = RSjetStruct._spectrum(self._tobs, self._nu, self._tcross, self._Fnumaxrs, self._numrs, self._nucutrs, self._nuars, self._p, self._k, specnum = 2, decelerated = True)   
-                y12 = RSjetStruct._spectrum(self._tobs, self._nu, self._tcross, self._Fnumaxrs, self._numrs, self._nucutrs, self._nuars, self._p, self._k, specnum = 1, decelerated = True) 
-                
+                y22 = RSjetStruct._spectrum(self._tobs, self._nu, self._tcross, self._Fnumaxrs, self._numrs, self._nucutrs, self._nuars, self._p, self._k, specnum = 2, decelerated = True)
+                y12 = RSjetStruct._spectrum(self._tobs, self._nu, self._tcross, self._Fnumaxrs, self._numrs, self._nucutrs, self._nuars, self._p, self._k, specnum = 1, decelerated = True)
+
                 #spect = y31*(self._tobs < self._tcross) + y32*(self._tobs >= self._tcross)
-                if tx2 is np.nan or tx2 >= largeTime:  
+                if tx4 is np.nan or tx4 >= largeTime: # no first post-decel crossing
                     spect = y31*(self._tobs < self._tcross) + y32*(self._tobs >= self._tcross)
                 elif tx3 is np.nan or tx3 >= largeTime: # in the case that post deceleration nua falls below nucut but not below num
                     spect = y31*(self._tobs < self._tcross) + (w32a*y32+w22a*y22)/(w32a+w22a)*(self._tobs >= self._tcross)
@@ -395,13 +430,21 @@ class RSjetStruct:
     @np.vectorize # TODO figure out a way to do without np.vectorize here to take advantage of spectrum.py's vectorization
     def _spectrum(_tobs, _nu, _tcross, _Fnumaxrs, _numrs, _nucutrs, _nuars, _p, _k, diagnostic = False, specnum = None, decelerated = None):
         """"""
-        _Fnutruemaxrs = obsFluxMax(_Fnumaxrs, smallNum, _nuars, _numrs, _nucutrs, p = _p)
-        
+        if specnum is None:
+            _Fnutruemaxrs = obsFluxMax(_Fnumaxrs, smallNum, _nuars, _numrs, _nucutrs, p = _p)
+        else:
+            # When the spectrum index is forced (weighted-average path),
+            # also force the matching SSA normalisation. The default
+            # obsFluxMax dispatches by frequency ordering and would
+            # otherwise return the spec-1 normalisation whenever the
+            # current ordering happens to be nua < num < nuc.
+            _Fnutruemaxrs = obsFluxMaxBySpecnum(_Fnumaxrs, smallNum, _nuars, _numrs, _nucutrs, _p, specnum)
+
         if decelerated is None:
             cut = _tobs > _tcross
         else:
             cut = decelerated
-        
+
         spec = Spectrum(_nu, _Fnutruemaxrs, smallNum, _nuars, _numrs, _nucutrs, p = _p, k = _k, cutoff = cut, specnum = specnum)
         
         nu, Fnu = spec.spectrum()


### PR DESCRIPTION
## Summary

Three independent issues in `Spectrum` / `RSjetStruct._spectrum` cause the post-deceleration weighted-average spectrum in `_spectrumweighted` to collapse to a single specnum component rather than smoothly interpolating between specnum 1, 2 and (where applicable) 3. As a result, with `k_eps = k_gam = 0` (structure off), the RS spectrum does not agree with a top-hat-jet RS calculation. After the fixes:

- pre-deceleration ratio (this code / top-hat) is exactly 1.0 across all frequencies
- post-deceleration is a flat plateau below the cooling break, with the expected smooth fall-off above it (no more wavy ratio)

## Fixes

### 1. `Spectrum.spectrum()` dispatch (`gsspectshapes.py`)
Each branch was

```python
if (natural ordering) or self._specnum == N:
```

The natural ordering short-circuits the `or`, so a call with `specnum=2` silently returns the spec-1 result whenever the actual break frequencies happen to be in spec-1 ordering — which is exactly the regime where `_spectrumweighted` needs `y22` to differ from `y12`. Reordered to specnum-first:

```python
if self._specnum == N or (self._specnum is None and natural ordering):
```

### 2. `obsFluxMax` SSA normalisation (`rsjetstruct.py`)
`obsFluxMax` also dispatches by frequency ordering, so even after (1), `Spectrum` was being fed the spec-1 `Fnumax` when computing a forced spec-2 component, leaving `Fnu4` off by `(num/nua)^((p-1)/2)`. Added `obsFluxMaxBySpecnum` (case formulae selected by specnum) and routed `_spectrum` through it whenever `specnum` is explicit. The `specnum is None` path is unchanged.

### 3. Cutoff smoothing outer exponent (`gsspectshapes.py`)
`_tildeFnuCUT12`, `_FnuCUT3`, `_FnuCUT4` and `_tildeFnuCUT5` all ended in `(...)**(-s)` where the standard GS02 smoothing form (used in every other `_Fnub`/`_tildeFnub` in the same file) is `(...)**(-1/s)`. With `s=2` at low nu the buggy form gives `1.541^(-2) ≈ 0.421` instead of `1.541^(-1/2) ≈ 0.806`. The 0.421 was directly observable as the constant ~0.595 ratio (top-hat / this code) in a structure-off comparison.

## Incidental cleanups in `_spectrumweighted`
Two small follow-on issues in the wind branches surfaced while tracing the dispatch problem:
- `tx2 >= largeTime` should have been `tx3 >= largeTime` in the wind case A else-branch.
- Missing `w32a/w22a/w22b/w12b` weight definitions and a `tx4` vs `tx3` selection in the wind branch where `nuars` rises above both `num` and `nucut` post-deceleration.

## Verification

Diagnostic against `rs.rsspect` (no structure) for `RSjetStruct` with `keps=kgam=0`, default template parameters (`p=2.5`, `g=5`, `nua0=7e9`, `num0=2e10`, `nuc0=1e13`, `fnum0=10`, `tdec=5.787e-4`):

| t            | low-nu ratio | high-nu (~nuc) |
|--------------|--------------|---------------|
| pre-dec      | 1.0000       | 1.0000        |
| 1.7·tdec     | 1.139        | 1.04          |
| 17·tdec      | 1.139        | 1.31 (cutoff) |

The residual ~1.139 plateau is a convention difference in the cutoff smoothing (`(1+2e^-2)^(-1/2) ≈ 0.806` here vs `1/sqrt(2) ≈ 0.707` in the comparison code), not a bug.

## Test plan
- [ ] CI / existing tests pass
- [ ] Visual check of `rs-breakfreqs-mwe.ipynb` (or equivalent) — ratio of structure-off RS spectrum to a top-hat reference is flat below the cooling break